### PR TITLE
Fixes #12 Split technical and custom data in scenario results

### DIFF
--- a/Xunit.ScenarioReporting/Results/Assertion.cs
+++ b/Xunit.ScenarioReporting/Results/Assertion.cs
@@ -1,15 +1,14 @@
 using System;
-using System.Collections.Generic;
 
 namespace Xunit.ScenarioReporting.Results
 {
     internal class Assertion : Then
     {
-        public Assertion(string title) : base(title, (IReadOnlyList<Detail>) new Detail[] { })
+        public Assertion(string scope, string title) : base(scope, title, new Detail[] { })
         {
         }
 
-        public Assertion(string title, Exception ex) : base(title, (IReadOnlyList<Detail>) new[] { ExceptionToDetail(ex) }) { }
+        public Assertion(string scope, string title, Exception ex) : base(scope, title, new[] { ExceptionToDetail(ex) }) { }
 
         static Detail ExceptionToDetail(Exception ex)
         {

--- a/Xunit.ScenarioReporting/Results/Then.cs
+++ b/Xunit.ScenarioReporting/Results/Then.cs
@@ -4,9 +4,11 @@ namespace Xunit.ScenarioReporting.Results
 {
     internal class Then : ReportEntry
     {
-        public Then(string title, IReadOnlyList<Detail> details) : base(title, details)
-        {
+        public string Scope { get; }
 
+        public Then(string scope, string title, IReadOnlyList<Detail> details) : base(title, details)
+        {
+            Scope = scope;
         }
     }
 }

--- a/Xunit.ScenarioReporting/ScenarioReport.cs
+++ b/Xunit.ScenarioReporting/ScenarioReport.cs
@@ -70,7 +70,7 @@ namespace Xunit.ScenarioReporting
             try
             {
                 var writer = new DelayedBatchWriter(_queue);
-                writer.Write(new StartScenario(result.Title));
+                writer.Write(new StartScenario(result.Title, result.Scope));
                 foreach (var given in result.Given)
                     writer.Write(given);
                 if(result.When != null)

--- a/Xunit.ScenarioReporting/ScenarioReportingTestInvoker.cs
+++ b/Xunit.ScenarioReporting/ScenarioReportingTestInvoker.cs
@@ -30,6 +30,7 @@ namespace Xunit.ScenarioReporting
         protected override object CallTestMethod(object testClassInstance)
         {
             object result = null;
+            var testMethodName = ((ScenarioReportingXunitTestCase)TestCase).TestMethodName;
             try
             {
                 result = base.CallTestMethod(testClassInstance);
@@ -52,7 +53,7 @@ namespace Xunit.ScenarioReporting
                 }
                 if (_scenarioRunner != null)
                 {
-                    _scenarioRunner.AddResult(TestCase.DisplayName);
+                    _scenarioRunner.AddResult(testMethodName, TestCase.DisplayName);
                 }
                 return result;
             }
@@ -60,7 +61,7 @@ namespace Xunit.ScenarioReporting
             {
                 if (_scenarioRunner != null && !(e is ScenarioVerificationException))
                 {
-                    _scenarioRunner.AddResult(TestCase.DisplayName, e.Unwrap());
+                    _scenarioRunner.AddResult(testMethodName, TestCase.DisplayName, e.Unwrap());
                 }
                 Aggregator.Add(e.Unwrap());
                 return result;
@@ -71,7 +72,7 @@ namespace Xunit.ScenarioReporting
         {
             if(_scenarioRunner!= null)
                 throw new InvalidOperationException(Constants.Errors.DontReturnScenarioResults);
-            result.Title = result.Title ?? name;
+            result.Scope = name;
             _report.Report(result);
             result.ThrowIfErrored();
         }

--- a/Xunit.ScenarioReporting/ScenarioReportingXunitTestCase.cs
+++ b/Xunit.ScenarioReporting/ScenarioReportingXunitTestCase.cs
@@ -22,8 +22,10 @@ namespace Xunit.ScenarioReporting
             object[] testMethodArguments = null)
             : base(diagnosticMessageSink, defaultMethodDisplay, testMethod, testMethodArguments)
         {
-
+            TestMethodName = BaseDisplayName;
         }
+
+        public string TestMethodName { get; }
 
         public override Task<RunSummary> RunAsync(IMessageSink diagnosticMessageSink, IMessageBus messageBus,
             object[] constructorArguments,

--- a/Xunit.ScenarioReporting/ScenarioReportingXunitTestCollectionRunner.cs
+++ b/Xunit.ScenarioReporting/ScenarioReportingXunitTestCollectionRunner.cs
@@ -29,48 +29,6 @@ namespace Xunit.ScenarioReporting
             _diagnosticMessageSink = diagnosticMessageSink;
         }
 
-        //protected override void CreateCollectionFixture(Type fixtureType)
-        //{
-        //    if (CollectionFixtureMappings.ContainsKey(fixtureType)) return;
-        //    if (fixtureType.IsSubclassOf(typeof(Definition)))
-        //    {
-        //        Aggregator.Run(() =>
-        //        {
-        //            var ctors = fixtureType.GetConstructors();
-        //            if (ctors.Length > 1) throw new InvalidOperationException($"Definition type {fixtureType.FullName} can only have 1 public constructor");
-        //            if (ctors.Length == 0) throw new InvalidOperationException($"Definition type {fixtureType.FullName} must have a public constructor");
-
-        //            var ctor = ctors[0];
-
-        //            var missingParameters = new List<ParameterInfo>();
-        //            var ctorArgs = ctor.GetParameters().Select(p =>
-        //            {
-        //                object arg;
-        //                if (!CollectionFixtureMappings.TryGetValue(p.ParameterType, out arg))
-        //                    missingParameters.Add(p);
-        //                return arg;
-        //            }).ToArray();
-
-        //            if (missingParameters.Count > 0)
-        //                Aggregator.Add(new TestClassException(
-        //                    $"Definition type '{fixtureType.FullName}' had one or more unresolved constructor arguments: {string.Join(", ", missingParameters.Select(p => $"{p.ParameterType.Name} {p.Name}"))}"
-        //                ));
-        //            else
-        //            {
-        //                CollectionFixtureMappings[fixtureType] = _scenarioRunner = (Definition)ctor.Invoke(ctorArgs);
-        //                _scenarioRunner.Title = TestCollection.CollectionDefinition.Name;
-        //            }
-        //        });
-        //    }
-        //    else
-        //    {
-        //        object value;
-        //        if (!CollectionFixtureMappings.TryGetValue(fixtureType, out value))
-        //        {
-        //            Aggregator.Run(() => CollectionFixtureMappings[fixtureType] = Activator.CreateInstance(fixtureType));
-        //        }
-        //    }
-        //}
         protected override async Task AfterTestCollectionStartingAsync()
         {
             await base.AfterTestCollectionStartingAsync();
@@ -78,7 +36,7 @@ namespace Xunit.ScenarioReporting
             {
                 _scenarioRunner = CollectionFixtureMappings.Values.OfType<ScenarioRunner>().SingleOrDefault();
                 if (_scenarioRunner != null)
-                    _scenarioRunner.Title = TestCollection.CollectionDefinition.Name;
+                    _scenarioRunner.Scope = TestCollection.CollectionDefinition.Name;
             });
         }
 

--- a/Xunit.ScenarioReporting/ScenarioRunner.cs
+++ b/Xunit.ScenarioReporting/ScenarioRunner.cs
@@ -28,9 +28,9 @@ namespace Xunit.ScenarioReporting
             _thens = new List<Then>();
         }
 
-        internal void AddResult(string name, Exception e = null)
+        internal void AddResult(string scope, string name, Exception e = null)
         {
-            _thens.Add(e != null ? new Assertion(name, e) : new Assertion(name));
+            _thens.Add(e != null ? new Assertion(scope, name, e) : new Assertion(scope, name));
         }
         
         /// <summary>
@@ -111,7 +111,7 @@ namespace Xunit.ScenarioReporting
         protected void RecordThen(string title, Action<IAddThenDetail> detailBuilder)
         {
             var details = BuildDetails(detailBuilder);
-            _thens.Add(new Then(title, details));
+            _thens.Add(new Then(null, title, details));
         }
 
         private static List<Detail> BuildDetails(Action<IAddDetail> detailBuilder)
@@ -173,9 +173,9 @@ namespace Xunit.ScenarioReporting
                     _error = ExceptionDispatchInfo.Capture(ex);
                 }
                 if (_when == null)
-                    AddResult("Incomplete scenario", new Exception("No when provided"));
+                    AddResult(null, "Incomplete scenario", new Exception("No when provided"));
             }
-            return new ScenarioRunResult(Title, _givens, _when ?? NullWhen, _thens, _error);
+            return new ScenarioRunResult(Title, _givens, _when ?? NullWhen, _thens, _error){Scope = Scope};
         }
         static readonly When NullWhen = new When("No when provided", new Detail[]{});
         private ExceptionDispatchInfo _error;
@@ -192,5 +192,6 @@ namespace Xunit.ScenarioReporting
         /// the name of the class fixture. if returned from a test, then the name of the test will be used.
         /// </summary>
         public string Title { get; set; }
+        public string Scope { get; internal set; }
     }
 }

--- a/Xunit.ScenarioReporting/ScenarioXunitTestClassRunner.cs
+++ b/Xunit.ScenarioReporting/ScenarioXunitTestClassRunner.cs
@@ -43,7 +43,7 @@ namespace Xunit.ScenarioReporting
             {
                 _scenarioRunner = ClassFixtureMappings.Values.OfType<ScenarioRunner>().SingleOrDefault();
                 if(_scenarioRunner != null)
-                    _scenarioRunner.Title = Class.Name;
+                    _scenarioRunner.Scope = Class.Name;
             });
         }
 

--- a/Xunit.ScenarioReporting/StartScenario.cs
+++ b/Xunit.ScenarioReporting/StartScenario.cs
@@ -3,10 +3,12 @@ namespace Xunit.ScenarioReporting
     class StartScenario : ReportItem
     {
         public string Name { get; }
+        public string Scope { get; }
 
-        public StartScenario(string name)
+        public StartScenario(string name, string scope)
         {
             Name = name;
+            Scope = scope;
         }
     }
 }


### PR DESCRIPTION
Added scope to result and then types. also added scope to scenario start
If the title is set then the scope will not override it.