### PR TITLE
Don't include static properties in object comparison

### DIFF
--- a/Xunit.ScenarioReporting.Tests/DeepComparisonTests.cs
+++ b/Xunit.ScenarioReporting.Tests/DeepComparisonTests.cs
@@ -76,8 +76,19 @@ namespace Xunit.ScenarioReporting.Tests
                 Second = second;
             }
         }
-}
 
-    
+        struct TestStruct
+        {
+            public static readonly TestStruct EmptyField = new TestStruct();
 
+            public static TestStruct Empty { get; } = new TestStruct();
+        }
+
+        [Fact]
+        public void CanCompareObjectWithStaticProperty()
+        {
+            // Ensure this does not hang on infinite recursion of field/property
+            _comparer.Compare("scope", new TestStruct(), new TestStruct());
+        }
+    }
 }

--- a/Xunit.ScenarioReporting/ReflectionPropertyWalker.cs
+++ b/Xunit.ScenarioReporting/ReflectionPropertyWalker.cs
@@ -109,7 +109,7 @@ namespace Xunit.ScenarioReporting
                             };
                         }
                     }
-                    foreach (var p in current.Type.GetProperties().Reverse())
+                    foreach (var p in current.Type.GetProperties(BindingFlags.Public | BindingFlags.Instance).Reverse())
                     {
                         if (_skipProperty(current.Type, p.Name) || _skipProperty(p.DeclaringType, p.Name)) continue;
                         value = p.GetValue(current.Value);


### PR DESCRIPTION
Got stuck in an infinite loop in object comparison due to a static property returning an instance of the same type...

e.g.

```csharp
public struct SomeId
{
    public static SomeId Empty { get; } = new SomeId();
}
```